### PR TITLE
Remove transition animation for URLs

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -71,7 +71,6 @@ nav a {
   font-size: 0.6em;
   letter-spacing: var(--h-kerning);
   padding: 1em 2em;
-  transition: none 200ms ease-out;
   transition-property: color, background;
 }
 


### PR DESCRIPTION
Right now, we aren't consistent between `<nav>` URLs and `class="post"` ones.

My personal preference is to remove the transitions, but I ultimately just want consistency.